### PR TITLE
Corrects some problems converting to compilable MSL from SPIRV.

### DIFF
--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1175,9 +1175,17 @@ void Compiler::parse(const Instruction &instruction)
 
 		auto decoration = static_cast<Decoration>(ops[1]);
 		if (length >= 3)
+		{
 			set_decoration(id, decoration, ops[2]);
+			if (meta.at(id).decoration.alias.empty())
+				set_name(id, "m_" + convert_to_string(id));
+		}
 		else
+		{
 			set_decoration(id, decoration);
+			if (meta.at(id).decoration.alias.empty())
+				set_name(id, "m_" + convert_to_string(id));
+		}
 		break;
 	}
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -510,6 +510,12 @@ void CompilerMSL::emit_header()
 	statement("");
 	statement("using namespace metal;");
 	statement("");
+	statement("#define discard discard_fragment()");
+	statement("#define dFdy dfdy");
+	statement("#define dFdx dfdy");
+	statement("#define atan(x,y) atan2((y),(x))");
+	statement("inline bool greaterThan(float2 a,float2 b) { return all(a>b) ? true : false; }");
+	statement("inline uint2 imageSize(thread const texture2d<float>& tex) { return uint2(tex.get_width(), tex.get_height()); }");
 }
 
 void CompilerMSL::emit_resources()
@@ -1568,7 +1574,7 @@ string CompilerMSL::builtin_to_glsl(BuiltIn builtin)
 	switch (builtin)
 	{
 	case BuiltInPosition:
-		return (stage_out_var_name + ".gl_Position");
+		return qual_pos_var_name.empty() ? (stage_out_var_name + ".gl_Position") : qual_pos_var_name;
 	case BuiltInPointSize:
 		return (stage_out_var_name + ".gl_PointSize");
 	case BuiltInVertexId:


### PR DESCRIPTION
 A better solution is to refactor the glsl compiler base-class so some keywords and actions can be overridden, and then the msl subclass can override them - this is a quick & dirty solution.

 - adds some common macros that correct for intrinsic differences
 - adds some inline functions to adapt for GLSL terms
 - injects structure member names when the original SPV has been stripped - there is another way to use the correct temporarily assigned member name, but using m_<id> based on the inside SPV code yields metal code that more correctly maps to the original SPV opcodes/slots.